### PR TITLE
Handle parallel cores and Windows cluster cleanup

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -90,6 +90,17 @@ bootstrap <- function(qteparams, qteest, func) {
     
     eachIter <- list()
 
+    if (!isTRUE(pl)) {
+        cores <- NULL
+    } else if (.Platform$OS.type == "windows" &&
+               is.numeric(cores) &&
+               length(cores) == 1L &&
+               !is.na(cores) &&
+               cores > 1) {
+        cores <- parallel::makeCluster(as.integer(cores))
+        on.exit(parallel::stopCluster(cores), add=TRUE)
+    }
+
     eachIter <- pblapply(1:iters, bootiter, qteparams=qteparams,
                          func=func, cl=cores)
     ## if (pl) {


### PR DESCRIPTION
In bootstrap(), ensure the `cores` argument is set to NULL when parallel flag `pl` is not TRUE, and on Windows create a parallel cluster object when `cores` is a single numeric > 1. Also register an on.exit() to stop the cluster, preventing orphaned worker processes. These changes make pblapply() receive an appropriate `cl` and ensure proper cleanup on Windows when using multiple cores.